### PR TITLE
Update tests to expose problems with overlapped candidate chars.

### DIFF
--- a/Tests/MegrezTests/MegrezTests.swift
+++ b/Tests/MegrezTests/MegrezTests.swift
@@ -26,7 +26,11 @@ final class MegrezTests: XCTestCase {
 		builder.insertReadingAtCursor(reading: "zhong1")
 		builder.insertReadingAtCursor(reading: "jiang3")
 		builder.insertReadingAtCursor(reading: "jin1")
+		builder.insertReadingAtCursor(reading: "ni3")
+		builder.insertReadingAtCursor(reading: "zhe4")
+		builder.insertReadingAtCursor(reading: "yang4")
 
+		
 		let walker = Megrez.Walker(grid: builder.grid())
 
 		var walked: [Megrez.NodeAnchor] = walker.reverseWalk(at: builder.grid().width(), score: 0.0)
@@ -39,7 +43,7 @@ final class MegrezTests: XCTestCase {
 			}
 		}
 		print(composed)
-		let correctResult = ["高科技", "公司", "的", "年中", "獎金"]
+		let correctResult = ["高科技", "公司", "的", "年中", "獎金", "你", "這樣"]
 		print(" - 上述列印結果理應於下面這行一致：")
 		print(correctResult)
 
@@ -213,4 +217,6 @@ jiang3jin1 獎金 -10.344678
 nian2zhong1 年終 -11.668947
 nian2zhong1 年中 -11.373044
 gao1ke1ji4 高科技 -9.842421
+ni3zhe4 你這 -9.000000
+zhe4yang4 這樣 -8.000000
 """#

--- a/main.swift
+++ b/main.swift
@@ -110,6 +110,8 @@ jiang3jin1 獎金 -10.344678
 nian2zhong1 年終 -11.668947
 nian2zhong1 年中 -11.373044
 gao1ke1ji4 高科技 -9.842421
+ni3zhe4 你這 -9.000000
+zhe4yang4 這樣 -8.000000
 """#
 
 // MARK: - 用以測試的型別
@@ -193,7 +195,7 @@ func testInput() {
 		}
 	}
 	print(composed)
-	let correctResult = ["高科技", "公司", "的", "年中", "獎金"]
+	let correctResult = ["高科技", "公司", "的", "年中", "獎金", "你", "這樣"]
 	print(" - 上述列印結果理應於下面這行一致：")
 	print(correctResult)
 }


### PR DESCRIPTION
When you type things with overlapped candidate chars, the overlapped candidate chars gets duplicated.
For example: typing 你這樣, you get a wrong result instead: 你這這樣.
<img width="844" alt="image" src="https://user-images.githubusercontent.com/3164826/165980734-fabd38d6-3555-47bd-ae80-282d2d237f27.png">

P.S.: The issue mentioned in this PR will be solved in another PR.
P.P.S.: The entire test suite needs further development to test possible hard situations.
It seems that it doesn't respond to user candidate selection-confirmation behavior, but at this moment we don't have a method to figure out whether this is an input-method issue or an issue of this library.